### PR TITLE
Pin deploy build to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         uses: withastro/action@v3
+        with:
+          node-version: 22
         env:
           PUBLIC_GA4_ID: ${{ vars.PUBLIC_GA4_ID }}
 


### PR DESCRIPTION
## Summary
`withastro/action` defaults to Node 20; Astro 6 requires Node ≥22.12. The recent `main` deploys (PR #31 merge, PR #36 merge) both failed with `Node.js v20.20.2 is not supported by Astro!`. CI passed because the CI workflow already pins Node 22 — this aligns the deploy workflow with CI.

## Test plan
- [ ] CI build on this PR passes.
- [ ] Post-merge deploy succeeds.
- [ ] Live site reflects Astro 6 build + content-fixes (typo + book update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)