### PR TITLE
Auto-merge minor/patch Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for minor and patch updates
+        if: contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.meta.outputs.update-type)
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a workflow that enables GitHub's auto-merge on Dependabot PRs that bump minor or patch versions. Major bumps still require manual review.

The actual merge still waits for the `build` status check to pass (per the existing branch ruleset), so nothing lands red.

## Test plan
- [ ] CI build passes on this PR.
- [ ] Once merged, the next Dependabot PR with a minor/patch bump should land automatically after CI succeeds.
- [ ] Major bumps continue to wait for manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)