### PR TITLE
Remove leftover dependabot.yml comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,4 @@
 version: 2
-
-# Touching this file triggers a Dependabot re-evaluation on merge.
 updates:
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
Cleanup of the no-op trigger comment from the auto-merge test. Auto-merge enabled — will land when CI passes.