### PR TITLE
Visual refresh: serif headings, dates, tags, archive, and more

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,4 +4,9 @@ import sitemap from "@astrojs/sitemap";
 export default defineConfig({
   site: "https://bradgignac.com",
   integrations: [sitemap()],
+  markdown: {
+    shikiConfig: {
+      theme: "monokai",
+    },
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.3",
+        "@fontsource-variable/newsreader": "^5.2.10",
         "astro": "^6.4.4",
         "sass": "1.100.0"
       }
@@ -621,6 +622,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/newsreader": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/newsreader/-/newsreader-5.2.10.tgz",
+      "integrity": "sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
+    "@fontsource-variable/newsreader": "^5.2.10",
     "astro": "^6.4.4",
     "sass": "1.100.0"
   }

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#ca3a00"/>
+  <path d="M 8 50 L 24 24 L 36 38 L 44 28 L 56 50 Z" fill="#f6f6f6"/>
+</svg>

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,0 +1,36 @@
+---
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  posts: Array<CollectionEntry<"posts">>;
+}
+
+const { posts } = Astro.props;
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+---
+
+<ul class="bg-post-list">
+  {posts.map((post) => (
+    <li class="bg-post-list-item">
+      <div class="bg-post-list-date">
+        {dateFormatter.format(post.data.date)}
+      </div>
+      <div class="bg-post-list-title">
+        <a href={`/posts/${post.id}/`}>{post.data.title}</a>
+        {post.data.tags && post.data.tags.length > 0 && (
+          <ul class="bg-post-list-tags">
+            {post.data.tags.map((tag) => (
+              <li class="bg-post-list-tag">{tag}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </li>
+  ))}
+</ul>

--- a/src/content/posts/avoiding-complexity-with-go.md
+++ b/src/content/posts/avoiding-complexity-with-go.md
@@ -1,6 +1,10 @@
 ---
 date: 2014-09-24
 title: Avoiding Complexity with Go
+tags:
+  - Go
+  - Simplicity
+  - Software Design
 ---
 
 In ["No Silver Bullet"](http://en.wikipedia.org/wiki/No_Silver_Bullet), Fred 

--- a/src/content/posts/front-end-operations.md
+++ b/src/content/posts/front-end-operations.md
@@ -2,6 +2,7 @@
 date: 2014-05-20
 title: Front-End Operations
 tags:
+  - Tech Talk
   - HTML
   - CSS
   - JavaScript

--- a/src/content/posts/intro-to-coreos.md
+++ b/src/content/posts/intro-to-coreos.md
@@ -2,6 +2,7 @@
 date: 2014-08-12
 title: Intro to CoreOS
 tags:
+  - Tech Talk
   - CoreOS
   - Docker
   - Vulcand

--- a/src/content/posts/sending-email-with-python-and-the-mailgun-api.md
+++ b/src/content/posts/sending-email-with-python-and-the-mailgun-api.md
@@ -28,7 +28,8 @@ system:
 Now that you have all the necessary prerequisites, let's dive straight into the code:
 
 <figcaption>send-email.py</figcaption>
-{% highlight python %}
+
+```python
 import requests
 
 key = 'YOUR API KEY HERE'
@@ -45,7 +46,7 @@ request = requests.post(request_url, auth=('api', key), data={
 
 print 'Status: {0}'.format(request.status_code)
 print 'Body:   {0}'.format(request.text)
-{% endhighlight %}
+```
 
 If you run the Python script from your terminal, you'll receive an email in just
 a few minutes. This only scratches the surface of what the Mailgun API provides.
@@ -59,7 +60,8 @@ delivered. Mailgun provides the [Events API](http://documentation.mailgun.com/ap
 for exactly this purpose.
 
 <figcaption>list-events.py</figcaption>
-{% highlight python %}
+
+```python
 import requests
 
 key = 'YOUR API KEY HERE'
@@ -70,7 +72,7 @@ request = requests.get(request_url, auth=('api', key), params={'limit': 5})
 
 print 'Status: {0}'.format(request.status_code)
 print 'Body:   {0}'.format(request.text)
-{% endhighlight %}
+```
 
 Run the Python script from your terminal, and you'll see the last five events
 that your emails have generated as they move through the system. In addition to

--- a/src/content/posts/understanding-the-shift-to-mobile.md
+++ b/src/content/posts/understanding-the-shift-to-mobile.md
@@ -2,6 +2,7 @@
 date: 2015-02-19
 title: Understanding the Shift to Mobile
 tags:
+  - Tech Talk
   - Mobile
   - Strategy
 ---

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import "@fontsource-variable/newsreader";
 import "../styles/site.scss";
 
 interface Props {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,6 +29,7 @@ const gaId = import.meta.env.PUBLIC_GA4_ID;
     <meta property="og:type" content="website" />
     <meta property="og:url" content={Astro.url.href} />
 
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="alternate" type="application/rss+xml" title="Brad Gignac" href="/rss.xml" />
     <link rel="sitemap" href="/sitemap-index.xml" />
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -5,9 +5,10 @@ import SiteFooter from "../components/SiteFooter.astro";
 interface Props {
   title: string;
   date: Date;
+  tags?: string[];
 }
 
-const { title, date } = Astro.props;
+const { title, date, tags } = Astro.props;
 const formattedDate = date.toLocaleDateString("en-US", {
   year: "numeric",
   month: "long",
@@ -37,6 +38,11 @@ const formattedDate = date.toLocaleDateString("en-US", {
           <header class="bg-post-header">
             <div class="bg-post-date">{formattedDate}</div>
             <h1 class="bg-post-title">{title}</h1>
+            {tags && tags.length > 0 && (
+              <ul class="bg-post-tags">
+                {tags.map((tag) => <li class="bg-post-tag">{tag}</li>)}
+              </ul>
+            )}
           </header>
           <div class="bg-post-content">
             <slot />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -21,6 +21,7 @@ const formattedDate = date.toLocaleDateString("en-US", {
 ---
 
 <BaseLayout title={title}>
+  <div class="bg-progress-bar" aria-hidden="true"></div>
   <header class="bg-header">
     <div class="bg-layout-outer">
       <div class="bg-layout-inner">

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,4 +1,5 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 
@@ -6,9 +7,11 @@ interface Props {
   title: string;
   date: Date;
   tags?: string[];
+  prev?: CollectionEntry<"posts"> | null;
+  next?: CollectionEntry<"posts"> | null;
 }
 
-const { title, date, tags } = Astro.props;
+const { title, date, tags, prev, next } = Astro.props;
 const formattedDate = date.toLocaleDateString("en-US", {
   year: "numeric",
   month: "long",
@@ -25,7 +28,7 @@ const formattedDate = date.toLocaleDateString("en-US", {
           Hello, my name is <a href="/"><strong>Brad Gignac</strong></a>.
         </div>
         <ul class="bg-header-navigation">
-          <li><a href="/">Back to Blog &raquo;</a></li>
+          <li><a href="/">Back to Blog &rarr;</a></li>
         </ul>
       </div>
     </div>
@@ -47,6 +50,25 @@ const formattedDate = date.toLocaleDateString("en-US", {
           <div class="bg-post-content">
             <slot />
           </div>
+          {(prev || next) && (
+            <nav class="bg-post-nav">
+              {prev && (
+                <a href={`/posts/${prev.id}/`} class="bg-post-nav-link">
+                  <span class="bg-post-nav-label">&larr; Previous</span>
+                  <span class="bg-post-nav-title">{prev.data.title}</span>
+                </a>
+              )}
+              {next && (
+                <a
+                  href={`/posts/${next.id}/`}
+                  class="bg-post-nav-link bg-post-nav-next"
+                >
+                  <span class="bg-post-nav-label">Next &rarr;</span>
+                  <span class="bg-post-nav-title">{next.data.title}</span>
+                </a>
+              )}
+            </nav>
+          )}
         </article>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,6 +47,13 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
                     </div>
                     <div class="bg-post-list-title">
                       <a href={`/posts/${post.id}/`}>{post.data.title}</a>
+                      {post.data.tags && post.data.tags.length > 0 && (
+                        <ul class="bg-post-list-tags">
+                          {post.data.tags.map((tag) => (
+                            <li class="bg-post-list-tag">{tag}</li>
+                          ))}
+                        </ul>
+                      )}
                     </div>
                   </li>
                 ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,17 +1,15 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
+import PostList from "../components/PostList.astro";
 
-const posts = (await getCollection("posts")).sort(
+const HOME_POST_LIMIT = 5;
+
+const allPosts = (await getCollection("posts")).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
-
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
-  year: "numeric",
-  month: "long",
-  day: "numeric",
-  timeZone: "UTC",
-});
+const posts = allPosts.slice(0, HOME_POST_LIMIT);
+const hasMore = allPosts.length > posts.length;
 ---
 
 <BaseLayout title="Home">
@@ -39,25 +37,12 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
           posts.length > 0 && (
             <>
               <hr />
-              <ul class="bg-post-list">
-                {posts.map((post) => (
-                  <li class="bg-post-list-item">
-                    <div class="bg-post-list-date">
-                      {dateFormatter.format(post.data.date)}
-                    </div>
-                    <div class="bg-post-list-title">
-                      <a href={`/posts/${post.id}/`}>{post.data.title}</a>
-                      {post.data.tags && post.data.tags.length > 0 && (
-                        <ul class="bg-post-list-tags">
-                          {post.data.tags.map((tag) => (
-                            <li class="bg-post-list-tag">{tag}</li>
-                          ))}
-                        </ul>
-                      )}
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              <PostList posts={posts} />
+              {hasMore && (
+                <p class="bg-post-list-more">
+                  <a href="/posts/">All posts &rarr;</a>
+                </p>
+              )}
             </>
           )
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,11 +41,11 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
               <hr />
               <ul class="bg-post-list">
                 {posts.map((post) => (
-                  <li class="bg-post-item">
-                    <div class="bg-post-date">
+                  <li class="bg-post-list-item">
+                    <div class="bg-post-list-date">
                       {dateFormatter.format(post.data.date)}
                     </div>
-                    <div class="bg-post-title">
+                    <div class="bg-post-list-title">
                       <a href={`/posts/${post.id}/`}>{post.data.title}</a>
                     </div>
                   </li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,13 +18,14 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   <section class="bg-content">
     <div class="bg-layout-outer">
       <div class="bg-layout-inner">
+        <h1>Hello, my name is Brad Gignac.</h1>
         <p>
-          <strong>Hello, my name is Brad Gignac</strong>. I'm a husband and
-          father living in Charlotte, NC. In my spare time, you'll find me
-          spending time with my family, listening to/playing music, traveling,
-          and exploring the outdoors. In my professional life, I work as a
-          software developer at <a href="https://prosperops.com">ProsperOps</a>.
-          Visit me elsewhere on <a href="https://github.com/bradgignac"
+          I'm a husband and father living in Charlotte, NC. In my spare time,
+          you'll find me spending time with my family, listening to/playing
+          music, traveling, and exploring the outdoors. In my professional
+          life, I work as a software developer at <a
+            href="https://prosperops.com">ProsperOps</a
+          >. Visit me elsewhere on <a href="https://github.com/bradgignac"
             >GitHub</a
           >, <a href="https://linkedin.com/in/bradgignac">LinkedIn</a>, <a
             href="https://speakerdeck.com/bradgignac">Speaker Deck</a

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -14,6 +14,6 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 ---
 
-<PostLayout title={post.data.title} date={post.data.date}>
+<PostLayout title={post.data.title} date={post.data.date} tags={post.data.tags}>
   <Content />
 </PostLayout>

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -3,17 +3,29 @@ import { getCollection, render } from "astro:content";
 import PostLayout from "../../layouts/PostLayout.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("posts");
-  return posts.map((post) => ({
+  const posts = (await getCollection("posts")).sort(
+    (a, b) => a.data.date.getTime() - b.data.date.getTime(),
+  );
+  return posts.map((post, i) => ({
     params: { slug: post.id },
-    props: { post },
+    props: {
+      post,
+      prev: i > 0 ? posts[i - 1] : null,
+      next: i < posts.length - 1 ? posts[i + 1] : null,
+    },
   }));
 }
 
-const { post } = Astro.props;
+const { post, prev, next } = Astro.props;
 const { Content } = await render(post);
 ---
 
-<PostLayout title={post.data.title} date={post.data.date} tags={post.data.tags}>
+<PostLayout
+  title={post.data.title}
+  date={post.data.date}
+  tags={post.data.tags}
+  prev={prev}
+  next={next}
+>
   <Content />
 </PostLayout>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -1,0 +1,43 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import SiteFooter from "../../components/SiteFooter.astro";
+import PostList from "../../components/PostList.astro";
+
+const posts = (await getCollection("posts")).sort(
+  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+---
+
+<style>
+  /* The h1's own top margin provides the gap from the page header. */
+  .bg-content {
+    margin-top: 0;
+  }
+</style>
+
+<BaseLayout title="All Posts">
+  <header class="bg-header">
+    <div class="bg-layout-outer">
+      <div class="bg-layout-inner">
+        <div class="bg-header-title">
+          Hello, my name is <a href="/"><strong>Brad Gignac</strong></a>.
+        </div>
+        <ul class="bg-header-navigation">
+          <li><a href="/">Back to Blog &rarr;</a></li>
+        </ul>
+      </div>
+    </div>
+  </header>
+
+  <section class="bg-content">
+    <div class="bg-layout-outer">
+      <div class="bg-layout-inner">
+        <h1>All Posts</h1>
+        <PostList posts={posts} />
+      </div>
+    </div>
+  </section>
+
+  <SiteFooter />
+</BaseLayout>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -42,10 +42,9 @@ figure {
 
 figcaption {
   margin: 1rem 0 0.2rem;
-  color: #999;
-  font-size: 0.8rem;
-  font-weight: 300;
-  line-height: 1rem;
+  color: #666;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85rem;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -68,6 +67,7 @@ hr {
 }
 
 pre {
-  margin: 0 0.8rem;
-  padding: 0.5rem 0;
+  margin: 0;
+  padding: 0.5rem 0.8rem;
+  border-radius: 0.5rem;
 }

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -21,11 +21,14 @@ a:hover {
 
 blockquote {
   margin: 1rem 0;
-  padding: 1rem;
-  font-size: 1.4rem;
+  padding: 0.5rem 0 0.5rem 1.5rem;
+  font-family: $serif-family;
+  font-size: 1.5rem;
   font-style: italic;
-  background-color: rgba(224, 224, 224, 0.25);
-  border-left: 3px solid $border-color;
+  font-weight: 300;
+  line-height: 1.4;
+  color: #666;
+  border-left: 4px solid color-mix(in srgb, $link-color, white 50%);
 }
 
 blockquote > p {
@@ -34,7 +37,7 @@ blockquote > p {
 }
 
 figure {
-  margin: 1em 0;
+  margin: 1rem 0;
 }
 
 figcaption {
@@ -46,8 +49,9 @@ figcaption {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  margin: 1em 0;
-  font-weight: 200;
+  margin: 1.5em 0 0.5em;
+  font-family: $serif-family;
+  font-weight: 400;
 }
 
 h1 { font-size: 2.0rem; line-height: 2rem; }

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -11,12 +11,20 @@ body {
 
 a {
   color: $link-color;
-  text-decoration: none;
-  transition: color 0.5s;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+  transition: color 0.5s, text-decoration-color 0.2s;
 }
 
-a:hover {
-  color: color-mix(in srgb, $link-color, black 10%);
+a:hover,
+a:focus-visible {
+  text-decoration-color: currentColor;
+}
+
+a:focus-visible {
+  outline: none;
 }
 
 blockquote {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -67,7 +67,7 @@ body {
 }
 
 .bg-content {
-  margin: 1em 0;
+  margin: 1rem 0;
   padding: 0 1rem;
 }
 
@@ -85,6 +85,6 @@ body {
 
   .bg-footer-navigation > li {
     display: inline;
-    margin: 0 1em;
+    margin: 0 1rem;
   }
 }

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -23,6 +23,24 @@
   margin: 0;
 }
 
+.bg-post-list-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bg-post-list-tag {
+  padding: 0 0.5rem;
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #666;
+  font-size: 0.7rem;
+  font-weight: 400;
+  border-radius: 0.25rem;
+}
+
 @media (min-width: 380px) {
   .bg-post-list-item {
     display: grid;
@@ -51,4 +69,22 @@
 
 .bg-post-title {
   margin: 0;
+}
+
+.bg-post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin: 0.4rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bg-post-tag {
+  padding: 0 0.5rem;
+  background-color: rgba(0, 0, 0, 0.05);
+  color: #666;
+  font-size: 0.7rem;
+  font-weight: 400;
+  border-radius: 0.25rem;
 }

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -10,14 +10,13 @@
 }
 
 .bg-post-header {
-  margin: 0 0 2.0rem;
+  margin: 0 0 2rem;
 }
 
 .bg-post-date {
   color: #999;
   font-size: 0.8rem;
   font-weight: 300;
-  line-height: 1rem;
 }
 
 .bg-post-title {
@@ -32,7 +31,7 @@
     align-items: baseline;
 
     > .bg-post-date {
-      margin-top: 0.5em;
+      margin-top: 0.5rem;
       text-align: right;
     }
   }

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -41,6 +41,12 @@
   border-radius: 0.25rem;
 }
 
+.bg-post-list-more {
+  margin: 1rem 0 0;
+  text-align: right;
+  font-size: 0.875rem;
+}
+
 @media (min-width: 380px) {
   .bg-post-list-item {
     display: grid;

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -1,38 +1,54 @@
 @use "variables" as *;
 
+// Post list — used on the home page.
 .bg-post-list {
   padding: 0;
   list-style: none;
 }
 
-.bg-post-item {
-  margin: 0.5rem 0;
+.bg-post-list-item {
+  margin: 0 0 1rem;
 }
 
+.bg-post-list-date {
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1;
+}
+
+.bg-post-list-title {
+  margin: 0;
+}
+
+@media (min-width: 380px) {
+  .bg-post-list-item {
+    display: grid;
+    grid-template-columns: 12rem 1fr;
+    gap: 0 $gutter;
+    align-items: baseline;
+  }
+
+  .bg-post-list-date {
+    text-align: right;
+  }
+}
+
+// Post header — used on individual post pages.
 .bg-post-header {
   margin: 0 0 2rem;
 }
 
 .bg-post-date {
-  color: #999;
-  font-size: 0.8rem;
-  font-weight: 300;
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .bg-post-title {
   margin: 0;
-}
-
-@media (min-width: $breakpoint-md) {
-  .bg-post-item {
-    display: grid;
-    grid-template-columns: 1fr 3fr;
-    gap: 0 $gutter;
-    align-items: baseline;
-
-    > .bg-post-date {
-      margin-top: 0.5rem;
-      text-align: right;
-    }
-  }
 }

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -47,6 +47,30 @@
   font-size: 0.875rem;
 }
 
+// Scroll progress indicator — a thin rust bar across the top of
+// the viewport that fills as the reader scrolls through a post.
+// Uses CSS scroll-driven animations; gracefully degrades to a
+// static empty bar in browsers without animation-timeline support.
+.bg-progress-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: $link-color;
+  transform: scaleX(0);
+  transform-origin: left;
+  z-index: 100;
+  animation: bg-progress linear forwards;
+  animation-timeline: scroll(root);
+}
+
+@keyframes bg-progress {
+  to {
+    transform: scaleX(1);
+  }
+}
+
 @media (min-width: 380px) {
   .bg-post-list-item {
     display: grid;

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -88,3 +88,35 @@
   font-weight: 400;
   border-radius: 0.25rem;
 }
+
+.bg-post-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.bg-post-nav-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-decoration: none;
+}
+
+.bg-post-nav-next {
+  grid-column: 2;
+  text-align: right;
+}
+
+.bg-post-nav-label {
+  color: #666;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.bg-post-nav-title {
+  font-family: $serif-family;
+  font-size: 1.1rem;
+  line-height: 1.3;
+}

--- a/src/styles/_print.scss
+++ b/src/styles/_print.scss
@@ -1,0 +1,62 @@
+@use "variables" as *;
+
+@media print {
+  body {
+    background: white;
+    color: black;
+    font-family: $serif-family;
+  }
+
+  // Drop non-essential chrome.
+  .bg-header,
+  .bg-footer,
+  .bg-post-nav,
+  .bg-post-list-tags,
+  .bg-post-tags {
+    display: none;
+  }
+
+  // Print external URLs alongside the link text. Skip internal
+  // links and #anchors — they're noise on paper.
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    color: #555;
+    font-size: 0.85em;
+    font-style: normal;
+    font-weight: normal;
+  }
+
+  // Strip the underline-on-hover/focus mechanics from print.
+  a {
+    text-decoration: underline;
+    text-decoration-color: currentColor;
+    text-decoration-thickness: 1px;
+  }
+
+  // Keep figures and quotations together.
+  .bg-post-header,
+  pre,
+  blockquote,
+  figure {
+    break-inside: avoid;
+  }
+
+  // Don't orphan a heading at the bottom of a page.
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid;
+  }
+
+  // Code blocks readable on paper — override Shiki's dark theme.
+  pre {
+    background: #f5f5f5 !important;
+    color: black !important;
+    border: 1px solid #ccc;
+    border-radius: 0;
+  }
+
+  // Figcaption visible on white.
+  figcaption {
+    background: transparent;
+    color: #444;
+  }
+}

--- a/src/styles/_reading.scss
+++ b/src/styles/_reading.scss
@@ -29,5 +29,6 @@
 .bg-reading-list-group-item-desc {
   margin-left: 0.5rem;
   color: #666;
+  font-family: $serif-family;
   font-style: italic;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -2,7 +2,9 @@ $background-color: #f6f6f6;
 $border-color: #e0e0e0;
 
 $font-color: #444;
-$font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+$sans-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+$serif-family: "Newsreader Variable", "Newsreader", Georgia, "Times New Roman", serif;
+$font-family: $sans-family;
 $font-size: 18px;
 $font-weight: 300;
 $line-height: 1.7rem;

--- a/src/styles/site.scss
+++ b/src/styles/site.scss
@@ -4,3 +4,4 @@
 @use "layout";
 @use "post";
 @use "reading";
+@use "print";


### PR DESCRIPTION
## Summary
Twelve commits worth of small, consistent visual moves to push the site from \"2014 dev template\" into editorial territory while preserving the rust-orange palette and content-first feel.

### Typography
- **Newsreader serif headings** paired with the existing Helvetica Neue body.
- **Heading rhythm** retuned (`1.5em 0 0.5em` so titles sit closer to the content they introduce).
- **Em → rem** conversion everywhere outside headings.
- **Landing greeting** promoted from inline bold to an h1.
- **Reading list notes** moved to serif italic.

### Lists and layout
- **Post list** dates rendered as small-caps labels in a 12rem gutter on the home page, collapsing to single column below 380px.
- **Post header** matches the same small-caps date treatment.
- **Post list and post header** now use distinct class names (`.bg-post-list-*` vs `.bg-post-*`) to stop sharing styles by accident.
- **Tag chips** under each post title in the list and post header. Audited existing posts; added \`Tech Talk\` to deck-bearing posts and tagged the previously untagged Go essay.
- **Home capped at 5 most recent posts**, with an \"All posts →\" link once there are more. New \`/posts/\` archive holds the full chronological list.

### Reading and navigation
- **Prev/next post navigation** at the bottom of each post, sorted by date.
- **Scroll progress indicator** — thin rust bar at the top of the viewport on post pages, CSS-only via \`animation-timeline: scroll()\`.
- **\"Back to Blog →\"** swapped to the same arrow style as the prev/next nav for consistency.

### Code
- **Shiki theme** set to \`monokai\`.
- **Pre/figcaption** restyled — figcaption reads as a monospace filename label; pre has soft 0.5rem corners and the dark background extends edge-to-edge.
- Fixed the previously broken Mailgun post (was using Jekyll's \`{% highlight %}\` Liquid tags).

### Polish
- **Blockquote** redesigned: serif italic at 1.5rem, 50%-mix rust border, no gray box.
- **Link hover** now reveals an underline (via \`text-decoration-color\` transition) and matches focus-visible.
- **Mountain favicon** — two-peak silhouette in cream on a rust tile.
- **Print stylesheet** — strips chrome, switches to serif, prints external URLs, lightens code blocks.

## Test plan
- [ ] CI build passes.
- [ ] Live site renders: home (5 posts + \"All posts →\"), /posts/ archive, any post page (prev/next + scroll bar), /reading-list/.
- [ ] Hover any body link → underline fades in.
- [ ] Tab through links → underline on keyboard focus (no separate browser ring).
- [ ] Cmd+P on a post → print preview shows the print stylesheet treatment.
- [ ] Browser tab shows the mountain favicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)