### PR TITLE
Add /new-post, /new-hike, /new-book slash commands

### DIFF
--- a/.claude/commands/new-book.md
+++ b/.claude/commands/new-book.md
@@ -1,0 +1,31 @@
+---
+description: Scaffold a new reading list entry in a fresh worktree
+---
+
+Walk Brad through adding a new book to the reading list. Steps:
+
+1. **Gather metadata** (AskUserQuestion or sequential prompts):
+   - Title (required)
+   - Author (required)
+   - Start date in YYYY-MM-DD (default today)
+   - End date in YYYY-MM-DD, OR "currently reading" to leave it null
+   - Link — Amazon, publisher, library URL, etc. (required)
+   - Notes (optional one-liner)
+2. **Slug** the title: lowercase with **underscores instead of spaces/hyphens** — this matches the existing snake_case convention in `src/content/books/` (e.g., `the_color_of_magic.md`, `the_horse_and_his_boy.md`). Drop punctuation entirely.
+3. **Abort** if `src/content/books/<slug>.md` already exists in the main checkout.
+4. **Create the worktree** per the global git conventions:
+   - `git -C /Users/brad.gignac/work/bradgignac/bradgignac.github.io worktree add /Users/brad.gignac/work/bradgignac/<slug> -b bradgignac/<slug> main`
+   - Symlink `.claude/settings.local.json` from the main checkout.
+5. **Write the book file** at `<worktree>/src/content/books/<slug>.md`:
+   ```yaml
+   ---
+   title: <title>
+   author: <author>
+   start_date: <YYYY-MM-DD>
+   end_date: <YYYY-MM-DD or ~ for currently reading>
+   link: <url>
+   notes: <notes line>   # omit entirely if not provided
+   ---
+   ```
+   Body empty.
+6. **Report** the absolute path. Ask Brad to commit / push / PR when satisfied.

--- a/.claude/commands/new-hike.md
+++ b/.claude/commands/new-hike.md
@@ -1,0 +1,22 @@
+---
+description: Scaffold a new hike entry in a fresh worktree
+---
+
+Walk Brad through starting a new hike entry. Steps:
+
+1. **Gather metadata** (AskUserQuestion or sequential prompts):
+   - Hike title (required)
+   - Date in YYYY-MM-DD (default today)
+   - AllTrails widget URL — should match `https://www.alltrails.com/widget/recording/...` (required)
+   - Distance in miles (number, optional)
+   - Elevation gain in feet (integer, optional)
+   - Duration in **strict `Xh Xm Xs` format** like `1h 53m 24s` (optional — validate format if provided; the schema regex will reject anything else)
+   - Tags (comma-separated, optional)
+   - Gear (comma-separated, optional)
+2. **Slug** the title: lowercase, alphanumerics and hyphens only.
+3. **Abort** if `src/content/hikes/<slug>.md` already exists in the main checkout.
+4. **Create the worktree** per the global git conventions:
+   - `git -C /Users/brad.gignac/work/bradgignac/bradgignac.github.io worktree add /Users/brad.gignac/work/bradgignac/<slug> -b bradgignac/<slug> main`
+   - Symlink `.claude/settings.local.json` from the main checkout.
+5. **Write the hike file** at `<worktree>/src/content/hikes/<slug>.md`. Include only the frontmatter keys Brad actually provided, plus the always-required ones (`date`, `title`, `alltrails_url`). Body: `*Writeup coming soon — gear, conditions, and notes from the trail.*`
+6. **Report** the absolute path. Tell Brad to write the writeup body when ready and to ask you to commit / push / PR.

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -1,0 +1,24 @@
+---
+description: Scaffold a new blog post in a fresh worktree
+---
+
+Walk Brad through starting a new blog post. Steps:
+
+1. **Ask** for the post title and tags (optional, comma-separated). Use AskUserQuestion if more than one input is needed.
+2. **Slug** the title: lowercase, alphanumerics and hyphens only, no leading filler words ("the", "a", "an"). Show the slug and ask to confirm or override.
+3. **Abort** if `src/content/posts/<slug>.md` already exists on disk (check the main checkout — `/Users/brad.gignac/work/bradgignac/bradgignac.github.io/src/content/posts/<slug>.md`).
+4. **Create the worktree** per the global git conventions:
+   - `git -C /Users/brad.gignac/work/bradgignac/bradgignac.github.io worktree add /Users/brad.gignac/work/bradgignac/<slug> -b bradgignac/<slug> main`
+   - Symlink `.claude/settings.local.json` from the main checkout into the new worktree.
+5. **Write the post file** at `<worktree>/src/content/posts/<slug>.md`:
+   ```yaml
+   ---
+   date: <today YYYY-MM-DD>
+   title: <title>
+   tags:
+     - <tag>
+     - <tag>
+   ---
+   ```
+   Omit the `tags:` key entirely if Brad gave no tags. Leave the body empty (no placeholder text).
+6. **Report** the absolute file path and tell Brad to write the post body. He should ask you to commit / push / PR when he's ready to ship.


### PR DESCRIPTION
## Summary
Project-local slash commands under \`.claude/commands/\` for scaffolding new content. Each one:

- Asks for the frontmatter fields specific to the collection
- Generates the right slug style (kebab-case for posts/hikes, snake_case for books to match existing convention)
- Creates a fresh worktree per the git conventions (\`bradgignac/<slug>\` branch, symlinked personal-config)
- Writes the file with valid frontmatter
- Hands off to me to write the body

### Commands

- **\`/new-post\`** — blog post in \`src/content/posts/\`.
- **\`/new-hike\`** — hike entry in \`src/content/hikes/\`. Captures distance, elevation, duration (\`Xh Xm Xs\`), tags, gear.
- **\`/new-book\`** — reading list entry in \`src/content/books/\`. Handles \`end_date: ~\` for currently-reading books.

## Test plan
- [ ] After merge, invoke each command in a fresh Claude session and confirm the workflow lands a valid file in a new worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)