### PR TITLE
Add dev-server and spellcheck steps to new-content slash commands

### DIFF
--- a/.claude/commands/new-book.md
+++ b/.claude/commands/new-book.md
@@ -28,4 +28,14 @@ Walk Brad through adding a new book to the reading list. Steps:
    ---
    ```
    Body empty.
-6. **Report** the absolute path. Ask Brad to commit / push / PR when satisfied.
+6. **Install deps and start the dev server** in the new worktree so Brad can preview the reading list with HMR:
+   - `npm install --prefix <worktree>` (run in background, wait for it to finish)
+   - `npm run dev --prefix <worktree> -- --host 127.0.0.1 --port 4321` (run in background)
+   - Wait until the server responds at <http://localhost:4321/reading-list/>, then share the URL.
+7. **Report** the absolute path and the dev URL. Ask Brad to commit / push / PR when satisfied.
+
+### Before committing
+When Brad asks you to commit / push / PR, run `npx cspell --no-progress` first. If it fails:
+- If the flagged word is a real typo, fix it.
+- If it's a legitimate proper noun (book title, author, etc.), add it to `.cspell.json`.
+Only commit once cspell is clean.

--- a/.claude/commands/new-hike.md
+++ b/.claude/commands/new-hike.md
@@ -19,4 +19,14 @@ Walk Brad through starting a new hike entry. Steps:
    - `git -C /Users/brad.gignac/work/bradgignac/bradgignac.github.io worktree add /Users/brad.gignac/work/bradgignac/<slug> -b bradgignac/<slug> main`
    - Symlink `.claude/settings.local.json` from the main checkout.
 5. **Write the hike file** at `<worktree>/src/content/hikes/<slug>.md`. Include only the frontmatter keys Brad actually provided, plus the always-required ones (`date`, `title`, `alltrails_url`). Body: `*Writeup coming soon — gear, conditions, and notes from the trail.*`
-6. **Report** the absolute path. Tell Brad to write the writeup body when ready and to ask you to commit / push / PR.
+6. **Install deps and start the dev server** in the new worktree so Brad can see HMR previews while he writes:
+   - `npm install --prefix <worktree>` (run in background, wait for it to finish)
+   - `npm run dev --prefix <worktree> -- --host 127.0.0.1 --port 4321` (run in background)
+   - Wait until the server responds at <http://localhost:4321/>, then share the URL.
+7. **Report** the absolute path and the dev URL. Tell Brad to write the writeup body when ready and to ask you to commit / push / PR.
+
+### Before committing
+When Brad asks you to commit / push / PR, run `npx cspell --no-progress` first. If it fails:
+- If the flagged word is a real typo, fix it in the writeup.
+- If it's a legitimate proper noun (gear brand, trail name, place name), add it to `.cspell.json`.
+Only commit once cspell is clean.

--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -21,4 +21,14 @@ Walk Brad through starting a new blog post. Steps:
    ---
    ```
    Omit the `tags:` key entirely if Brad gave no tags. Leave the body empty (no placeholder text).
-6. **Report** the absolute file path and tell Brad to write the post body. He should ask you to commit / push / PR when he's ready to ship.
+6. **Install deps and start the dev server** in the new worktree so Brad can see HMR previews while he writes:
+   - `npm install --prefix <worktree>` (run in background, wait for it to finish)
+   - `npm run dev --prefix <worktree> -- --host 127.0.0.1 --port 4321` (run in background)
+   - Wait until the server responds at <http://localhost:4321/>, then share the URL.
+7. **Report** the absolute file path and the dev URL. Tell Brad to write the post body and ask you to commit / push / PR when he's ready.
+
+### Before committing
+When Brad asks you to commit / push / PR, run `npx cspell --no-progress` first. If it fails:
+- If the flagged word is a real typo, fix it in the post.
+- If it's a legitimate proper noun, add it to `.cspell.json`.
+Only commit once cspell is clean.


### PR DESCRIPTION
Follow-up to PR #51. Each `/new-*` command now also installs deps + starts the dev server on the new worktree (HMR previews while writing) and runs `cspell` as a precondition to commit/PR (fix typos or add proper nouns to `.cspell.json` before committing).