### PR TITLE
Unify home page and /posts/ behind a grouped feed

### DIFF
--- a/src/components/FeedList.astro
+++ b/src/components/FeedList.astro
@@ -1,0 +1,63 @@
+---
+export interface FeedItem {
+  type: "Blog" | "Hike" | "Book";
+  date: Date;
+  title: string;
+  url: string;
+  tags?: string[];
+}
+
+interface Props {
+  items: FeedItem[];
+}
+
+const { items } = Astro.props;
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  timeZone: "UTC",
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+const groups: Array<{ key: string; items: FeedItem[] }> = [];
+for (const item of items) {
+  const key = monthFormatter.format(item.date);
+  const last = groups[groups.length - 1];
+  if (last && last.key === key) {
+    last.items.push(item);
+  } else {
+    groups.push({ key, items: [item] });
+  }
+}
+---
+
+<ul class="bg-feed-list">
+  {groups.map((group) => (
+    <li class="bg-feed-group">
+      <div class="bg-feed-group-month">{group.key}</div>
+      <ul class="bg-feed-group-items">
+        {group.items.map((item) => (
+          <li class="bg-feed-item">
+            <a href={item.url}>{item.title}</a>
+            <span class="bg-feed-item-date">
+              {dateFormatter.format(item.date)}
+            </span>
+            {item.tags && item.tags.length > 0 && (
+              <ul class="bg-post-list-tags">
+                {item.tags.map((tag) => (
+                  <li class="bg-post-list-tag">{tag}</li>
+                ))}
+              </ul>
+            )}
+          </li>
+        ))}
+      </ul>
+    </li>
+  ))}
+</ul>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,39 @@
 ---
 import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import PostList from "../components/PostList.astro";
+import FeedList, { type FeedItem } from "../components/FeedList.astro";
 import SectionNav from "../components/SectionNav.astro";
 
-const HOME_POST_LIMIT = 5;
+const [posts, hikes, books] = await Promise.all([
+  getCollection("posts"),
+  getCollection("hikes"),
+  getCollection("books"),
+]);
 
-const allPosts = (await getCollection("posts")).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
-const posts = allPosts.slice(0, HOME_POST_LIMIT);
-const hasMore = allPosts.length > posts.length;
+const items: FeedItem[] = [
+  ...posts.map((p) => ({
+    type: "Blog" as const,
+    date: p.data.date,
+    title: p.data.title,
+    url: `/posts/${p.id}/`,
+    tags: p.data.tags,
+  })),
+  ...hikes.map((h) => ({
+    type: "Hike" as const,
+    date: h.data.date,
+    title: h.data.title,
+    url: `/hikes/${h.id}/`,
+    tags: h.data.tags,
+  })),
+  ...books.map((b) => ({
+    type: "Book" as const,
+    date: b.data.end_date ?? b.data.start_date,
+    title: `${b.data.title} — ${b.data.author}`,
+    url: b.data.link,
+  })),
+];
+
+items.sort((a, b) => b.date.getTime() - a.date.getTime());
 ---
 
 <BaseLayout title="Home">
@@ -37,15 +60,10 @@ const hasMore = allPosts.length > posts.length;
         <SectionNav showLabel />
 
         {
-          posts.length > 0 && (
+          items.length > 0 && (
             <>
               <hr />
-              <PostList posts={posts} />
-              {hasMore && (
-                <p class="bg-post-list-more">
-                  <a href="/posts/">All posts &rarr;</a>
-                </p>
-              )}
+              <FeedList items={items} />
             </>
           )
         }

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -2,12 +2,20 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import SiteFooter from "../../components/SiteFooter.astro";
-import PostList from "../../components/PostList.astro";
+import FeedList, { type FeedItem } from "../../components/FeedList.astro";
 import SectionNav from "../../components/SectionNav.astro";
 
 const posts = (await getCollection("posts")).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime(),
 );
+
+const items: FeedItem[] = posts.map((p) => ({
+  type: "Blog" as const,
+  date: p.data.date,
+  title: p.data.title,
+  url: `/posts/${p.id}/`,
+  tags: p.data.tags,
+}));
 ---
 
 <style>
@@ -33,7 +41,7 @@ const posts = (await getCollection("posts")).sort(
     <div class="bg-layout-outer">
       <div class="bg-layout-inner">
         <h1>All Posts</h1>
-        <PostList posts={posts} />
+        <FeedList items={items} />
       </div>
     </div>
   </section>

--- a/src/styles/_post.scss
+++ b/src/styles/_post.scss
@@ -47,6 +47,64 @@
   font-size: 0.875rem;
 }
 
+.bg-feed-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bg-feed-group {
+  margin: 0 0 1.5rem;
+}
+
+.bg-feed-group:last-child {
+  margin-bottom: 0;
+}
+
+.bg-feed-group-month {
+  margin: 0 0 0.5rem;
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.bg-feed-group-items {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bg-feed-item {
+  margin: 0 0 0.5rem;
+}
+
+.bg-feed-item:last-child {
+  margin-bottom: 0;
+}
+
+.bg-feed-item-date {
+  margin-left: 0.4rem;
+  color: #888;
+  font-size: 0.85rem;
+}
+
+@media (min-width: 380px) {
+  .bg-feed-group {
+    display: grid;
+    grid-template-columns: 12rem 1fr;
+    gap: 0 $gutter;
+    align-items: baseline;
+  }
+
+  .bg-feed-group-month {
+    margin: 0;
+    text-align: right;
+  }
+}
+
 // Scroll progress indicator — a thin rust bar across the top of
 // the viewport that fills as the reader scrolls through a post.
 // Uses CSS scroll-driven animations; gracefully degrades to a


### PR DESCRIPTION
## Summary
- Home page (\`/\`) and \`/posts/\` now share the same component (\`<FeedList>\`) and the same visual: items grouped by month/year, with the month label in the left gutter and the specific date inline beside the linked title.
- Home shows posts + hikes + books mixed chronologically. \`/posts/\` shows only blog posts.
- \`/hikes/\` and \`/reading-list/\` keep their custom layouts (year rollup on hikes, year-grouped books on reading list).
- Book rows link directly to their frontmatter URL (currently Amazon; Goodreads swap is on the horizon).

## Test plan
- [ ] \`/\` shows posts, hikes, and books interleaved.
- [ ] \`/posts/\` shows only blog posts, same visual treatment.
- [ ] \`/hikes/\` and \`/reading-list/\` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)