### PR TITLE
Refresh social links

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -5,11 +5,11 @@
   <div class="bg-layout-outer">
     <div class="bg-layout-inner">
       <ul class="bg-footer-navigation">
-        <li><a href="https://github.com/bradgignac">GitHub</a></li>
-        <li><a href="https://linkedin.com/in/bradgignac">LinkedIn</a></li>
-        <li><a href="https://speakerdeck.com/bradgignac">Speaker Deck</a></li>
-        <li><a href="https://www.alltrails.com/members/brad-gignac">AllTrails</a></li>
-        <li><a href="https://www.strava.com/athletes/bradgignac">Strava</a></li>
+        <li><a href="https://github.com/bradgignac" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+        <li><a href="https://linkedin.com/in/bradgignac" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+        <li><a href="https://www.instagram.com/bradgignac/" target="_blank" rel="noopener noreferrer">Instagram</a></li>
+        <li><a href="https://www.alltrails.com/members/brad-gignac" target="_blank" rel="noopener noreferrer">AllTrails</a></li>
+        <li><a href="https://outpack.app/u/FdTn4pwq" target="_blank" rel="noopener noreferrer">Outpack</a></li>
         <li><a href="/rss.xml">RSS</a></li>
       </ul>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -47,13 +47,26 @@ items.sort((a, b) => b.date.getTime() - a.date.getTime());
           music, traveling, and exploring the outdoors. In my professional
           life, I work as a software developer at <a
             href="https://prosperops.com">ProsperOps</a
-          >. Visit me elsewhere on <a href="https://github.com/bradgignac"
-            >GitHub</a
-          >, <a href="https://linkedin.com/in/bradgignac">LinkedIn</a>, <a
-            href="https://speakerdeck.com/bradgignac">Speaker Deck</a
-          >, <a href="https://www.alltrails.com/members/brad-gignac"
-            >AllTrails</a
-          >, and <a href="https://www.strava.com/athletes/bradgignac">Strava</a
+          >. Visit me elsewhere on <a
+            href="https://github.com/bradgignac"
+            target="_blank"
+            rel="noopener noreferrer">GitHub</a
+          >, <a
+            href="https://linkedin.com/in/bradgignac"
+            target="_blank"
+            rel="noopener noreferrer">LinkedIn</a
+          >, <a
+            href="https://www.instagram.com/bradgignac/"
+            target="_blank"
+            rel="noopener noreferrer">Instagram</a
+          >, <a
+            href="https://www.alltrails.com/members/brad-gignac"
+            target="_blank"
+            rel="noopener noreferrer">AllTrails</a
+          >, and <a
+            href="https://outpack.app/u/FdTn4pwq"
+            target="_blank"
+            rel="noopener noreferrer">Outpack</a
           >.
         </p>
 


### PR DESCRIPTION
Drops SpeakerDeck (linked from the relevant talk posts already) and Strava (not actively used). Adds Instagram and Outpack. All five social links open in a new tab via `target="_blank"`.