### PR TITLE
Tighten gear list spacing and downsize text

### DIFF
--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -82,18 +82,14 @@ pre {
 
 .bg-post-content ul,
 .bg-hike-gear-list {
-  margin: 1rem 0;
+  margin: 1rem 0 0;
   padding: 0;
   list-style: none;
 
   > li {
     position: relative;
     padding-left: 1.25rem;
-    margin: 0 0 0.4rem;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
+    margin: 0;
 
     &::before {
       content: "›";

--- a/src/styles/_hikes.scss
+++ b/src/styles/_hikes.scss
@@ -105,10 +105,11 @@
 
 .bg-hike-gear-list {
   margin: 0;
+  font-size: 0.9rem;
 }
 
 .bg-hike-gear-heading {
-  margin: 0 0 1rem;
+  margin: 0 0 0.5rem;
   color: $link-color;
   font-family: $sans-family;
   font-size: 0.75rem;


### PR DESCRIPTION
Drops vertical margins on content lists (`.bg-post-content ul` and `.bg-hike-gear-list`), shrinks the gear list to 0.9rem, and tightens the 'Gear' heading bottom margin to 0.5rem.