### PR TITLE
Reading list detail pages and Goodreads links

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,8 @@
     "fontsource",
     "frontmatter",
     "Gignac",
+    "Goodreads",
+    "goodreads",
     "Helvetica",
     "Jekyll",
     "kramdown",

--- a/src/components/FeedList.astro
+++ b/src/components/FeedList.astro
@@ -1,11 +1,5 @@
 ---
-export interface FeedItem {
-  type: "Blog" | "Hike" | "Book";
-  date: Date;
-  title: string;
-  url: string;
-  tags?: string[];
-}
+import type { FeedItem } from "../utils/feed";
 
 interface Props {
   items: FeedItem[];

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -17,8 +17,7 @@ const books = defineCollection({
     author: z.string(),
     start_date: z.date(),
     end_date: z.date().nullable(),
-    link: z.url(),
-    notes: z.string().nullable().optional(),
+    goodreads_url: z.url(),
   }),
 });
 

--- a/src/content/books/inspired.md
+++ b/src/content/books/inspired.md
@@ -3,6 +3,5 @@ title: "INSPIRED: How to Create Tech Products Customers Love"
 author: Marty Cagan
 start_date: 2018-04-02
 end_date: 2018-06-03
-link: https://www.amazon.com/gp/product/1119387507/ref=oh_aui_detailpage_o02_s00?ie=UTF8&psc=1
-notes: ~
+goodreads_url: https://www.goodreads.com/book/show/35249663-inspired
 ---

--- a/src/content/books/the_color_of_magic.md
+++ b/src/content/books/the_color_of_magic.md
@@ -3,5 +3,5 @@ title: The Color of Magic
 author: Terry Pratchett
 start_date: 2018-05-11
 end_date: 2018-06-02
-link: https://www.amazon.com/Color-Magic-Discworld-Terry-Pratchett/dp/0062225677
+goodreads_url: https://www.goodreads.com/book/show/34497.The_Color_of_Magic
 ---

--- a/src/content/books/the_girl_who_kicked_the_hornets_nest.md
+++ b/src/content/books/the_girl_who_kicked_the_hornets_nest.md
@@ -3,5 +3,5 @@ title: The Girl Who Kicked the Hornet's Nest
 author: Stieg Larsson
 start_date: 2018-01-31
 end_date: 2018-02-07
-link: https://www.amazon.com/Girl-Kicked-Hornets-Nest-Millennium/dp/0307742539/ref=pd_bxgy_14_2?_encoding=UTF8&pd_rd_i=0307742539&pd_rd_r=X3XARYBCS2RM3BTFFJM0&pd_rd_w=r7cfw&pd_rd_wg=DBIOr&psc=1&refRID=X3XARYBCS2RM3BTFFJM0
+goodreads_url: https://www.goodreads.com/book/show/6892870-the-girl-who-kicked-the-hornet-s-nest
 ---

--- a/src/content/books/the_girl_who_played_with_fire.md
+++ b/src/content/books/the_girl_who_played_with_fire.md
@@ -3,5 +3,5 @@ title: The Girl Who Played With Fire
 author: Stieg Larsson
 start_date: 2017-12-01
 end_date: 2018-01-31
-link: https://www.amazon.com/Girl-Who-Played-Fire-Millennium/dp/0307949508/ref=pd_lpo_sbs_14_t_0?_encoding=UTF8&psc=1&refRID=NEW66ET1QCZRMD02CZTC
+goodreads_url: https://www.goodreads.com/book/show/5060378-the-girl-who-played-with-fire
 ---

--- a/src/content/books/the_girl_with_the_dragon_tattoo.md
+++ b/src/content/books/the_girl_with_the_dragon_tattoo.md
@@ -3,5 +3,5 @@ title: The Girl With the Dragon Tattoo
 author: Stieg Larsson
 start_date: 2017-12-01
 end_date: 2017-12-31
-link: https://www.amazon.com/Girl-Dragon-Tattoo-Millennium/dp/0307949486
+goodreads_url: https://www.goodreads.com/book/show/2429135.The_Girl_With_the_Dragon_Tattoo
 ---

--- a/src/content/books/the_hobbit.md
+++ b/src/content/books/the_hobbit.md
@@ -3,6 +3,7 @@ title: The Hobbit
 author: J.R.R. Tolkien
 start_date: 2018-02-07
 end_date: 2018-02-12
-link: https://www.amazon.com/Hobbit-J-R-Tolkien/dp/054792822X/ref=nodl_
-notes: Belonged to my mom in college. Pages are yellowed.
+goodreads_url: https://www.goodreads.com/book/show/5907.The_Hobbit
 ---
+
+Belonged to my mom in college. Pages are yellowed.

--- a/src/content/books/the_horse_and_his_boy.md
+++ b/src/content/books/the_horse_and_his_boy.md
@@ -3,6 +3,7 @@ title: The Horse and His Boy
 author: C.S. Lewis
 start_date: 2018-05-02
 end_date: 2018-05-31
-link: https://www.amazon.com/gp/product/B001I45UFM/ref=series_rw_dp_sw
-notes: Read aloud to my daughter (and wife).
+goodreads_url: https://www.goodreads.com/book/show/84119.The_Horse_and_His_Boy
 ---
+
+Read aloud to my daughter (and wife).

--- a/src/content/books/the_lion_the_witch_and_the_wardrobe.md
+++ b/src/content/books/the_lion_the_witch_and_the_wardrobe.md
@@ -3,6 +3,7 @@ title: The Lion, the Witch, and the Wardrobe
 author: C.S. Lewis
 start_date: 2018-02-09
 end_date: 2018-05-01
-link: https://www.amazon.com/gp/product/B001I45UFC/ref=series_rw_dp_sw
-notes: Read aloud to my daughter (and wife).
+goodreads_url: https://www.goodreads.com/book/show/100915.The_Lion_the_Witch_and_the_Wardrobe
 ---
+
+Read aloud to my daughter (and wife).

--- a/src/content/books/the_magicians_nephew.md
+++ b/src/content/books/the_magicians_nephew.md
@@ -3,6 +3,7 @@ title: The Magician's Nephew
 author: C.S. Lewis
 start_date: 2018-01-08
 end_date: 2018-02-06
-link: https://www.amazon.com/Magicians-Nephew-Chronicles-Narnia-Book-ebook/dp/B001I45UF2/ref=sr_1_1?s=digital-text&ie=UTF8&qid=1517546253&sr=1-1&keywords=the+magicians+nephew
-notes: Read aloud to my daughter (and wife).
+goodreads_url: https://www.goodreads.com/book/show/65605.The_Magician_s_Nephew
 ---
+
+Read aloud to my daughter (and wife).

--- a/src/content/books/the_once_and_future_king.md
+++ b/src/content/books/the_once_and_future_king.md
@@ -3,6 +3,7 @@ title: The Once and Future King
 author: T.H. White
 start_date: 2018-02-12
 end_date: 2018-05-09
-link: https://www.amazon.com/Once-Future-King-T-White/dp/0441627404/ref=tmm_mmp_swatch_0?_encoding=UTF8&qid=&sr=
-notes: Also belonged to my mom in college. Pages are also yellowed.
+goodreads_url: https://www.goodreads.com/book/show/43545.The_Once_and_Future_King
 ---
+
+Also belonged to my mom in college. Pages are also yellowed.

--- a/src/layouts/BookLayout.astro
+++ b/src/layouts/BookLayout.astro
@@ -1,0 +1,74 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+import SiteFooter from "../components/SiteFooter.astro";
+import SectionNav from "../components/SectionNav.astro";
+
+interface Props {
+  title: string;
+  author: string;
+  start_date: Date;
+  end_date: Date | null;
+  goodreads_url: string;
+}
+
+const { title, author, start_date, end_date, goodreads_url } = Astro.props;
+
+const fullDateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+const shortDateFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+let dateLine: string;
+if (!end_date) {
+  dateLine = `Started ${fullDateFormatter.format(start_date)}`;
+} else if (start_date.getUTCFullYear() === end_date.getUTCFullYear()) {
+  dateLine = `${shortDateFormatter.format(start_date)} – ${fullDateFormatter.format(end_date)}`;
+} else {
+  dateLine = `${fullDateFormatter.format(start_date)} – ${fullDateFormatter.format(end_date)}`;
+}
+---
+
+<BaseLayout title={title}>
+  <header class="bg-header">
+    <div class="bg-layout-outer">
+      <div class="bg-layout-inner">
+        <div class="bg-header-title">
+          Hello, my name is <a href="/"><strong>Brad Gignac</strong></a>.
+        </div>
+        <SectionNav />
+      </div>
+    </div>
+  </header>
+
+  <section class="bg-content">
+    <div class="bg-layout-outer">
+      <div class="bg-layout-inner">
+        <article class="bg-post">
+          <header class="bg-post-header">
+            <div class="bg-post-date">{dateLine}</div>
+            <h1 class="bg-post-title">{title}</h1>
+            <div class="bg-book-byline">by {author}</div>
+          </header>
+          <div class="bg-post-content">
+            <slot />
+          </div>
+          <p class="bg-book-cta">
+            <a href={goodreads_url} target="_blank" rel="noopener">
+              View on Goodreads &rarr;
+            </a>
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <SiteFooter />
+</BaseLayout>

--- a/src/layouts/BookLayout.astro
+++ b/src/layouts/BookLayout.astro
@@ -58,16 +58,15 @@ if (!end_date) {
           <header class="bg-post-header">
             <div class="bg-post-date">{dateLine}</div>
             <h1 class="bg-post-title">{title}</h1>
-            <div class="bg-book-byline">by {author}</div>
+            <div class="bg-book-byline">
+              by {author}
+              <span class="bg-book-byline-sep">&middot;</span>
+              <a href={goodreads_url} target="_blank" rel="noopener">View on Goodreads &rarr;</a>
+            </div>
           </header>
           <div class="bg-post-content">
             <slot />
           </div>
-          <p class="bg-book-cta">
-            <a href={goodreads_url} target="_blank" rel="noopener">
-              View on Goodreads &rarr;
-            </a>
-          </p>
           {(prev || next) && (
             <nav class="bg-post-nav">
               {prev && (

--- a/src/layouts/BookLayout.astro
+++ b/src/layouts/BookLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SectionNav from "../components/SectionNav.astro";
+import type { FeedNavItem } from "../utils/feed";
 
 interface Props {
   title: string;
@@ -9,9 +10,11 @@ interface Props {
   start_date: Date;
   end_date: Date | null;
   goodreads_url: string;
+  prev?: FeedNavItem | null;
+  next?: FeedNavItem | null;
 }
 
-const { title, author, start_date, end_date, goodreads_url } = Astro.props;
+const { title, author, start_date, end_date, goodreads_url, prev, next } = Astro.props;
 
 const fullDateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
@@ -65,6 +68,25 @@ if (!end_date) {
               View on Goodreads &rarr;
             </a>
           </p>
+          {(prev || next) && (
+            <nav class="bg-post-nav">
+              {prev && (
+                <a href={prev.url} class="bg-post-nav-link">
+                  <span class="bg-post-nav-label">&larr; Previous</span>
+                  <span class="bg-post-nav-title">{prev.title}</span>
+                </a>
+              )}
+              {next && (
+                <a
+                  href={next.url}
+                  class="bg-post-nav-link bg-post-nav-next"
+                >
+                  <span class="bg-post-nav-label">Next &rarr;</span>
+                  <span class="bg-post-nav-title">{next.title}</span>
+                </a>
+              )}
+            </nav>
+          )}
         </article>
       </div>
     </div>

--- a/src/layouts/HikeLayout.astro
+++ b/src/layouts/HikeLayout.astro
@@ -3,6 +3,7 @@ import BaseLayout from "./BaseLayout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SectionNav from "../components/SectionNav.astro";
 import AllTrailsEmbed from "../components/AllTrailsEmbed.astro";
+import type { FeedNavItem } from "../utils/feed";
 
 interface Props {
   title: string;
@@ -13,9 +14,11 @@ interface Props {
   duration?: string;
   tags?: string[];
   gear?: string[];
+  prev?: FeedNavItem | null;
+  next?: FeedNavItem | null;
 }
 
-const { title, date, alltrails_url, distance_miles, elevation_gain_feet, duration, tags, gear } = Astro.props;
+const { title, date, alltrails_url, distance_miles, elevation_gain_feet, duration, tags, gear, prev, next } = Astro.props;
 const formattedDate = date.toLocaleDateString("en-US", {
   year: "numeric",
   month: "long",
@@ -87,6 +90,25 @@ if (duration) {
           <div class="bg-post-content">
             <slot />
           </div>
+          {(prev || next) && (
+            <nav class="bg-post-nav">
+              {prev && (
+                <a href={prev.url} class="bg-post-nav-link">
+                  <span class="bg-post-nav-label">&larr; Previous</span>
+                  <span class="bg-post-nav-title">{prev.title}</span>
+                </a>
+              )}
+              {next && (
+                <a
+                  href={next.url}
+                  class="bg-post-nav-link bg-post-nav-next"
+                >
+                  <span class="bg-post-nav-label">Next &rarr;</span>
+                  <span class="bg-post-nav-title">{next.title}</span>
+                </a>
+              )}
+            </nav>
+          )}
         </article>
       </div>
     </div>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -1,15 +1,15 @@
 ---
-import type { CollectionEntry } from "astro:content";
 import BaseLayout from "./BaseLayout.astro";
 import SiteFooter from "../components/SiteFooter.astro";
 import SectionNav from "../components/SectionNav.astro";
+import type { FeedNavItem } from "../utils/feed";
 
 interface Props {
   title: string;
   date: Date;
   tags?: string[];
-  prev?: CollectionEntry<"posts"> | null;
-  next?: CollectionEntry<"posts"> | null;
+  prev?: FeedNavItem | null;
+  next?: FeedNavItem | null;
 }
 
 const { title, date, tags, prev, next } = Astro.props;
@@ -53,18 +53,18 @@ const formattedDate = date.toLocaleDateString("en-US", {
           {(prev || next) && (
             <nav class="bg-post-nav">
               {prev && (
-                <a href={`/posts/${prev.id}/`} class="bg-post-nav-link">
+                <a href={prev.url} class="bg-post-nav-link">
                   <span class="bg-post-nav-label">&larr; Previous</span>
-                  <span class="bg-post-nav-title">{prev.data.title}</span>
+                  <span class="bg-post-nav-title">{prev.title}</span>
                 </a>
               )}
               {next && (
                 <a
-                  href={`/posts/${next.id}/`}
+                  href={next.url}
                   class="bg-post-nav-link bg-post-nav-next"
                 >
                   <span class="bg-post-nav-label">Next &rarr;</span>
-                  <span class="bg-post-nav-title">{next.data.title}</span>
+                  <span class="bg-post-nav-title">{next.title}</span>
                 </a>
               )}
             </nav>

--- a/src/pages/hikes/[...slug].astro
+++ b/src/pages/hikes/[...slug].astro
@@ -1,16 +1,23 @@
 ---
 import { getCollection, render } from "astro:content";
 import HikeLayout from "../../layouts/HikeLayout.astro";
+import { getFeedItems, getNeighbors } from "../../utils/feed";
 
 export async function getStaticPaths() {
-  const hikes = await getCollection("hikes");
+  const [hikes, feedItems] = await Promise.all([
+    getCollection("hikes"),
+    getFeedItems(),
+  ]);
   return hikes.map((hike) => ({
     params: { slug: hike.id },
-    props: { hike },
+    props: {
+      hike,
+      ...getNeighbors(feedItems, "hike", hike.id),
+    },
   }));
 }
 
-const { hike } = Astro.props;
+const { hike, prev, next } = Astro.props;
 const { Content } = await render(hike);
 ---
 
@@ -23,6 +30,8 @@ const { Content } = await render(hike);
   duration={hike.data.duration}
   tags={hike.data.tags}
   gear={hike.data.gear}
+  prev={prev}
+  next={next}
 >
   <Content />
 </HikeLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,39 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import BaseLayout from "../layouts/BaseLayout.astro";
-import FeedList, { type FeedItem } from "../components/FeedList.astro";
+import FeedList from "../components/FeedList.astro";
 import SectionNav from "../components/SectionNav.astro";
+import { getFeedItems } from "../utils/feed";
 
-const [posts, hikes, books] = await Promise.all([
-  getCollection("posts"),
-  getCollection("hikes"),
-  getCollection("books"),
-]);
-
-const items: FeedItem[] = [
-  ...posts.map((p) => ({
-    type: "Blog" as const,
-    date: p.data.date,
-    title: p.data.title,
-    url: `/posts/${p.id}/`,
-    tags: p.data.tags,
-  })),
-  ...hikes.map((h) => ({
-    type: "Hike" as const,
-    date: h.data.date,
-    title: h.data.title,
-    url: `/hikes/${h.id}/`,
-    tags: h.data.tags,
-  })),
-  ...books.map((b) => ({
-    type: "Book" as const,
-    date: b.data.end_date ?? b.data.start_date,
-    title: `${b.data.title} — ${b.data.author}`,
-    url: `/reading-list/${b.id}/`,
-  })),
-];
-
-items.sort((a, b) => b.date.getTime() - a.date.getTime());
+const items = await getFeedItems();
 ---
 
 <BaseLayout title="Home">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ const items: FeedItem[] = [
     type: "Book" as const,
     date: b.data.end_date ?? b.data.start_date,
     title: `${b.data.title} — ${b.data.author}`,
-    url: b.data.link,
+    url: `/reading-list/${b.id}/`,
   })),
 ];
 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,17 +1,18 @@
 ---
 import { getCollection, render } from "astro:content";
 import PostLayout from "../../layouts/PostLayout.astro";
+import { getFeedItems, getNeighbors } from "../../utils/feed";
 
 export async function getStaticPaths() {
-  const posts = (await getCollection("posts")).sort(
-    (a, b) => a.data.date.getTime() - b.data.date.getTime(),
-  );
-  return posts.map((post, i) => ({
+  const [posts, feedItems] = await Promise.all([
+    getCollection("posts"),
+    getFeedItems(),
+  ]);
+  return posts.map((post) => ({
     params: { slug: post.id },
     props: {
       post,
-      prev: i > 0 ? posts[i - 1] : null,
-      next: i < posts.length - 1 ? posts[i + 1] : null,
+      ...getNeighbors(feedItems, "post", post.id),
     },
   }));
 }

--- a/src/pages/reading-list.astro
+++ b/src/pages/reading-list.astro
@@ -64,10 +64,7 @@ for (const [, list] of sortedGroups) {
             <ul class="bg-reading-list-group">
               {list.map((book) => (
                 <li class="bg-reading-list-group-item">
-                  <a href={book.data.link} target="_blank" rel="noopener">{book.data.title}</a>, by {book.data.author}
-                  {book.data.notes && (
-                    <small class="bg-reading-list-group-item-desc">{book.data.notes}</small>
-                  )}
+                  <a href={`/reading-list/${book.id}/`}>{book.data.title}</a>, by {book.data.author}
                 </li>
               ))}
             </ul>

--- a/src/pages/reading-list/[...slug].astro
+++ b/src/pages/reading-list/[...slug].astro
@@ -1,0 +1,25 @@
+---
+import { getCollection, render } from "astro:content";
+import BookLayout from "../../layouts/BookLayout.astro";
+
+export async function getStaticPaths() {
+  const books = await getCollection("books");
+  return books.map((book) => ({
+    params: { slug: book.id },
+    props: { book },
+  }));
+}
+
+const { book } = Astro.props;
+const { Content } = await render(book);
+---
+
+<BookLayout
+  title={book.data.title}
+  author={book.data.author}
+  start_date={book.data.start_date}
+  end_date={book.data.end_date}
+  goodreads_url={book.data.goodreads_url}
+>
+  <Content />
+</BookLayout>

--- a/src/pages/reading-list/[...slug].astro
+++ b/src/pages/reading-list/[...slug].astro
@@ -1,16 +1,23 @@
 ---
 import { getCollection, render } from "astro:content";
 import BookLayout from "../../layouts/BookLayout.astro";
+import { getFeedItems, getNeighbors } from "../../utils/feed";
 
 export async function getStaticPaths() {
-  const books = await getCollection("books");
+  const [books, feedItems] = await Promise.all([
+    getCollection("books"),
+    getFeedItems(),
+  ]);
   return books.map((book) => ({
     params: { slug: book.id },
-    props: { book },
+    props: {
+      book,
+      ...getNeighbors(feedItems, "book", book.id),
+    },
   }));
 }
 
-const { book } = Astro.props;
+const { book, prev, next } = Astro.props;
 const { Content } = await render(book);
 ---
 
@@ -20,6 +27,8 @@ const { Content } = await render(book);
   start_date={book.data.start_date}
   end_date={book.data.end_date}
   goodreads_url={book.data.goodreads_url}
+  prev={prev}
+  next={next}
 >
   <Content />
 </BookLayout>

--- a/src/styles/_reading.scss
+++ b/src/styles/_reading.scss
@@ -32,3 +32,12 @@
   font-family: $serif-family;
   font-style: italic;
 }
+
+.bg-book-byline {
+  margin: 0.4rem 0 0;
+  font-family: $serif-family;
+  font-size: 1.1rem;
+  font-style: italic;
+  color: #666;
+}
+

--- a/src/styles/_reading.scss
+++ b/src/styles/_reading.scss
@@ -41,3 +41,7 @@
   color: #666;
 }
 
+.bg-book-byline-sep {
+  margin: 0 0.4rem;
+}
+

--- a/src/utils/feed.ts
+++ b/src/utils/feed.ts
@@ -1,0 +1,68 @@
+import { getCollection } from "astro:content";
+
+export interface FeedItem {
+  type: "post" | "hike" | "book";
+  id: string;
+  title: string;
+  date: Date;
+  url: string;
+  tags?: string[];
+}
+
+export interface FeedNavItem {
+  title: string;
+  url: string;
+}
+
+export async function getFeedItems(): Promise<FeedItem[]> {
+  const [posts, hikes, books] = await Promise.all([
+    getCollection("posts"),
+    getCollection("hikes"),
+    getCollection("books"),
+  ]);
+
+  const items: FeedItem[] = [
+    ...posts.map((p) => ({
+      type: "post" as const,
+      id: p.id,
+      title: p.data.title,
+      date: p.data.date,
+      url: `/posts/${p.id}/`,
+      tags: p.data.tags,
+    })),
+    ...hikes.map((h) => ({
+      type: "hike" as const,
+      id: h.id,
+      title: h.data.title,
+      date: h.data.date,
+      url: `/hikes/${h.id}/`,
+      tags: h.data.tags,
+    })),
+    ...books.map((b) => ({
+      type: "book" as const,
+      id: b.id,
+      title: `${b.data.title} — ${b.data.author}`,
+      date: b.data.end_date ?? b.data.start_date,
+      url: `/reading-list/${b.id}/`,
+    })),
+  ];
+
+  return items.sort((a, b) => b.date.getTime() - a.date.getTime());
+}
+
+// In a newest-first feed, "Previous" walks backward in time (higher index)
+// and "Next" walks forward (lower index).
+export function getNeighbors(
+  items: FeedItem[],
+  type: FeedItem["type"],
+  id: string,
+): { prev: FeedNavItem | null; next: FeedNavItem | null } {
+  const i = items.findIndex((it) => it.type === type && it.id === id);
+  if (i === -1) return { prev: null, next: null };
+  const prev = items[i + 1];
+  const next = items[i - 1];
+  return {
+    prev: prev ? { title: prev.title, url: prev.url } : null,
+    next: next ? { title: next.title, url: next.url } : null,
+  };
+}


### PR DESCRIPTION
## Summary

- Each book in the reading list now has its own detail page at \`/reading-list/<slug>/\` with byline, dates, body notes, and a "View on Goodreads" CTA.
- Notes moved from frontmatter to the markdown body so they can be richer than a single line.
- Schema rename: \`link\` -> \`goodreads_url\`; canonical Goodreads URLs swapped in for all 10 entries.
- Reading list and the unified home feed now link to the detail page instead of jumping out to Amazon.

## Test plan
- [ ] \`/reading-list/\` titles link to detail pages
- [ ] Detail page renders body notes (e.g. The Hobbit, The Once and Future King)
- [ ] "View on Goodreads" CTA opens in a new tab
- [ ] Home feed book entries route to detail pages